### PR TITLE
DPM-248 Try get ccache from sun.security.krb5 is KRB5CCNAME not set

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/KerberosUtil.java
+++ b/presto-client/src/main/java/io/prestosql/client/KerberosUtil.java
@@ -30,6 +30,11 @@ public final class KerberosUtil
         if (value.startsWith(FILE_PREFIX)) {
             value = value.substring(FILE_PREFIX.length());
         }
+        if (value.isEmpty()) {
+            // In case KRB5CCNAME is not set, we might still be able to get the ticket cache location using the Sun
+            // APIs. This allows unix clients (including MacOS) to connect despite this env variable not being set.
+            value = nullToEmpty(sun.security.krb5.internal.ccache.FileCredentialsCache.getDefaultCacheName());
+        }
         return Optional.ofNullable(emptyToNull(value));
     }
 }


### PR DESCRIPTION
In case KRB5CCNAME is not set, presto might still be able to get the
ticket cache location from the sun.security.krb5 implementation.

This allows clients on MacOS or on linux without the environment variable
set to still connect to the cluster without having to provide it
manually.