### PR TITLE
Fix CTAS failing when using viewfs+hive

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
@@ -403,7 +403,7 @@ class HdfsFileSystem
                 String prefix = (rawFileSystem instanceof ViewFileSystem) ? relativePrefix : temporaryPrefix;
 
                 // create a temporary directory on the same file system
-                Path temporaryRoot = new Path(targetPath, prefix);
+                Path temporaryRoot = new Path(targetPath.getParent(), prefix);
                 Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
                 Location temporaryLocation = Location.of(temporaryPath.toString());
 


### PR DESCRIPTION
This replicates c48a8a100e550b80e80e9c103a1aa0f5a64405d5.
`CREATE TABLE AS SELECT` fails due to the temporary directory being inside of the final directory, which is fixed by moving it to the parent directory instead.